### PR TITLE
added libcurl dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk --no-cache add --update -t deps git gcc make musl-dev \
     libxml2-dev libxslt-dev mariadb-dev openssl-dev libffi-dev \
     && apk --no-cache add bash ruby-bundler ruby-dev nodejs tzdata libxslt \
     mariadb-libs mariadb-client openssl ruby-io-console ruby-bigdecimal \
-    mariadb-client-libs curl-dev \
+    mariadb-client-libs curl-dev libcurl \
     && echo 'gem: --verbose --no-document' > /etc/gemrc; cd /tmp \
     && git clone https://github.com/SUSE/Portus.git . \
     && git checkout ${PORTUS_VERSION}; mkdir /portus \


### PR DESCRIPTION
without libcurl I get lots of libcurl errors

```
portus_2       | 2016-07-08T11:16:09.541648278Z /usr/lib/ruby/gems/2.3.0/gems/ffi-1.9.10/lib/ffi/library.rb:133:in `block in ffi_lib': Could not open library 'libcurl': Error loading shared library libcurl: No such file or directory. (LoadError)
portus_2       | 2016-07-08T11:16:09.542153072Z Could not open library 'libcurl.so': Error loading shared library libcurl.so: No such file or directory.
portus_2       | 2016-07-08T11:16:09.542179548Z Could not open library 'libcurl.so.4': Error loading shared library libcurl.so.4: No such file or directory.
portus_2       | 2016-07-08T11:16:09.542290116Z Could not open library 'libcurl.so.4.so': Error loading shared library libcurl.so.4.so: No such file or directory
```