### PR TITLE
Make SSL configurable

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -16,6 +16,10 @@ sed -i "s#XXX-PORTUS_MACHINE_FQDN-XXX#${PORTUS_MACHINE_FQDN}#" ${CONFIG_FILE}
 : ${PORTUS_DELETE_ENABLED:=false} && \
 sed -i "s#XXX-PORTUS_DELETE_ENABLED-XXX#${PORTUS_DELETE_ENABLED}#" ${CONFIG_FILE}
 
+# SSL enabled:
+: ${PORTUS_CHECK_SSL_USAGE_ENABLED:=false} && \
+sed -i "s#XXX-PORTUS_CHECK_SSL_USAGE_ENABLED-XXX#${PORTUS_CHECK_SSL_USAGE_ENABLED}#" ${CONFIG_FILE}
+
 # Adapter:
 : ${MARIADB_ADAPTER:=mysql2} && \
 sed -i "s#XXX-MARIADB_ADAPTER-XXX#${MARIADB_ADAPTER}#" ${DB_CONFIG_FILE}
@@ -92,6 +96,6 @@ cat ${DB_CONFIG_FILE}
 echo "--[${SECRETS_CONFIG_FILE}]------------------------------------------------------"
 cat ${SECRETS_CONFIG_FILE}
 
-[[ "${PUMA_SSL_KEY}" && "${PUMA_SSL_CRT}" ]] && \
+[[ "${PORTUS_CHECK_SSL_USAGE_ENABLED}" == "true" && "${PUMA_SSL_KEY}" && "${PUMA_SSL_CRT}" ]] && \
 exec env puma -e ${RACK_ENV} -b "ssl://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-443}?key=${PUMA_SSL_KEY}&cert=${PUMA_SSL_CRT}" -w ${PUMA_WORKERS:-3} ||
 exec env puma -e ${RACK_ENV} -b "tcp://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-80}" -w ${PUMA_WORKERS:-3}

--- a/rootfs/portus/config/config.yml
+++ b/rootfs/portus/config/config.yml
@@ -33,7 +33,7 @@ first_user_admin:
 signup:
   enabled: true
 check_ssl_usage:
-  enabled: true
+  enabled: XXX-PORTUS_CHECK_SSL_USAGE_ENABLED-XXX
 jwt_expiration_time:
   value: "5.minutes"
 machine_fqdn:


### PR DESCRIPTION
I've used this to run Portus behind a reverse proxy which handles SSL for me. It seems that the image is intended to degrade to HTTP when you don't give Puma a certificate and key, but there's a check inside Portus which causes this to break.