### PR TITLE
Fix client SSL connections from Portus.

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -85,7 +85,7 @@ mysql -h ${MARIADB_SERVICE_HOST} -P ${MARIADB_PORT} -u ${MARIADB_USER} -p${MARIA
 #------------------------------------------------------------------------------
 
 [ "${PORT0}" ] && [ ! "${PUMA_PORT}" ] && PUMA_PORT="${PORT0}"
-export SSL_CERT_DIR=${SSL_CERT_DIR:-/certs} && c_rehash ${SSL_CERT_DIR}
+export SSL_CERT_DIR=${SSL_CERT_DIR:-/certs:/usr/local/share/ca-certificates:/etc/ssl/certs} && c_rehash
 
 echo "--[${CONFIG_FILE}]------------------------------------------------------"
 cat ${CONFIG_FILE}


### PR DESCRIPTION
Setting the `SSL_CERT_DIR` environment variable means that the standard
certificate paths are ignored, so when Portus tries to connect to a registry as
a client (e.g. when a delete operation is requested) over SSL, it generates an
SSL verify error unless the ca is present in the `/certs` dir - the problem is
standard paths like `/etc/ssl/certs` are ignored, and you get verify errors from
trusted SSL certificates.