### PR TITLE
Fix `config.yml` desync with upstream.

### DIFF
--- a/rootfs/portus/config/config.yml
+++ b/rootfs/portus/config/config.yml
@@ -34,9 +34,19 @@ signup:
   enabled: true
 check_ssl_usage:
   enabled: XXX-PORTUS_CHECK_SSL_USAGE_ENABLED-XXX
-jwt_expiration_time:
-  value: "5.minutes"
+registry:
+  jwt_expiration_time:
+    value: 5
+  catalog_page:
+    value: 100
 machine_fqdn:
   value: XXX-PORTUS_MACHINE_FQDN-XXX
 display_name:
   enabled: false
+user_permission:
+  change_visibility:
+    enabled: true
+  manage_team:
+    enabled: true
+  manage_namespace:
+    enabled: true


### PR DESCRIPTION
Some configuration parameters are missing from the configuration, so we get a
500 internal server error upon creating a new team:

```
Processing by TeamsController#create as JS
  Parameters: {"utf8"=>"✓", "team"=>{"name"=>"redacted", "description"=>"redacted"}, "commit"=>"Add"}
Completed 500 Internal Server Error in 8ms (ActiveRecord: 0.3ms)

NoMethodError (undefined method `[]' for nil:NilClass):
  lib/portus/config.rb:50:in `block in add_enabled'
  app/policies/team_policy.rb:19:in `create?'
  app/controllers/teams_controller.rb:28:in `create'
```

The code that is responsible for this:

```ruby
[47, 56] in /portus/lib/portus/config.rb
   47:     def add_enabled(obj)
   48:       obj.define_singleton_method(:enabled?) do |feature|
   49:         objs = feature.split(".")
   50:         if objs.length == 2
   51:    byebug
=> 52:           return false if !self[objs[0]][objs[1]] || self[objs[0]][objs[1]].empty?
   53:           self[objs[0]][objs[1]]["enabled"].eql?(true)
   54:         else
   55:           return false if !self[feature] || self[feature].empty?
   56:           self[feature]["enabled"].eql?(true)
(byebug) objs
["user_permission", "manage_team"]
(byebug) obj
{"email"=>{"from"=>"portus@example.com", "name"=>"Portus", "reply_to"=>"no-reply@example.com", "smtp"=>{"enabled"=>false, "address"=>"smtp.example.com", "port"=>587, "user_name"=>"username@example.com", "
password"=>"password", "domain"=>"example.com"}}, "gravatar"=>{"enabled"=>true}, "delete"=>{"enabled"=>true}, "ldap"=>{"enabled"=>false, "hostname"=>"ldap_hostname", "port"=>389, "method"=>"plain", "base"
=>"", "filter"=>"", "uid"=>"uid", "authentication"=>{"enabled"=>false, "bind_dn"=>"", "password"=>""}, "guess_email"=>{"enabled"=>false, "attr"=>""}}, "first_user_admin"=>{"enabled"=>true}, "signup"=>{"en
abled"=>true}, "check_ssl_usage"=>{"enabled"=>false}, "jwt_expiration_time"=>{"value"=>"5.minutes"}, "machine_fqdn"=>{"value"=>"registry.oucs.ox.ac.uk"}, "display_name"=>{"enabled"=>false}}
(byebug) !self[objs[0]][objs[1]] || self[objs[0]][objs[1]].empty?
*** NoMethodError Exception: undefined method `[]' for nil:NilClass

nil
```

This commit introduces the (presumably) new configuration options, as per
https://github.com/SUSE/Portus/blob/master/config/config.yml, which fixes these
issues.