### PR TITLE
Added ability to set puma worker timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ ENV PORTUS_VERSION="2.1.0" \
 
 RUN apk --no-cache add --update -t deps git gcc make musl-dev libxml2-dev \
     libxslt-dev mariadb-dev openssl-dev libffi-dev curl-dev \
-    && apk --no-cache add bash ruby-bundler ruby-dev nodejs tzdata libxslt \
-    mariadb-libs mariadb-client openssl ruby-io-console ruby-bigdecimal \
-    mariadb-client-libs libcurl \
+    && apk --no-cache add bash ruby-bundler ruby-dev ruby-rdoc ruby-irb \
+    nodejs tzdata libxslt mariadb-libs mariadb-client openssl ruby-io-console \
+    ruby-bigdecimal mariadb-client-libs libcurl \
     && echo 'gem: --verbose --no-document' > /etc/gemrc; cd /tmp \
     && git clone https://github.com/SUSE/Portus.git . \
     && git checkout ${PORTUS_VERSION}; mkdir /portus \

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cd portus && docker run -it --rm \
 --env RAILS_ENV=production \
 --env PUMA_SSL_KEY=/certs/server-key.pem \
 --env PUMA_SSL_CRT=/certs/server-crt.pem \
+--env PUMA_WORKER_TIMEOUT=60 \
 --env PUMA_IP=127.0.0.1 \
 --env PUMA_PORT=443 \
 --env PUMA_WORKERS=4 \

--- a/rootfs/init
+++ b/rootfs/init
@@ -7,6 +7,7 @@
 CONFIG_FILE='/portus/config/config.yml'
 DB_CONFIG_FILE='/portus/config/database.yml'
 SECRETS_CONFIG_FILE='/portus/config/secrets.yml'
+PUMA_CONFIG_FILE='portus/config/puma.rb'
 
 # Machine fqdn:
 : ${PORTUS_MACHINE_FQDN:=127.0.0.1} && \
@@ -60,6 +61,11 @@ sed -i "s#XXX-PORTUS_ENCRYPTION_PRIVATE_KEY_PATH-XXX#${PORTUS_ENCRYPTION_PRIVATE
 : ${PORTUS_PORTUS_PASSWORD:=portus} && \
 sed -i "s#XXX-PORTUS_PORTUS_PASSWORD-XXX#${PORTUS_PORTUS_PASSWORD}#" ${SECRETS_CONFIG_FILE}
 
+# Puma worker timeout:
+: ${PUMA_WORKER_TIMEOUT:=60} && \
+sed -i "s#XXX-PUMA_WORKER_TIMEOUT-XXX#${PUMA_WORKER_TIMEOUT}#" ${PUMA_CONFIG_FILE}
+
+
 # Set Rack and Rails environment:
 export RACK_ENV=${RACK_ENV:-production}
 export RAILS_ENV=${RAILS_ENV:-production}
@@ -101,5 +107,5 @@ mysql -h ${MARIADB_HOST} -P ${MARIADB_PORT} -u ${MARIADB_USER} -p${MARIADB_PASSW
 export SSL_CERT_DIR=${SSL_CERT_DIR:-/certs:/usr/local/share/ca-certificates:/etc/ssl/certs} && c_rehash
 
 [[ "${PORTUS_CHECK_SSL_USAGE_ENABLED}" == "true" && "${PUMA_SSL_KEY}" && "${PUMA_SSL_CRT}" ]] && \
-exec env puma -e ${RACK_ENV} -b "ssl://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-443}?key=${PUMA_SSL_KEY}&cert=${PUMA_SSL_CRT}" -w ${PUMA_WORKERS:-3} ||
-exec env puma -e ${RACK_ENV} -b "tcp://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-80}" -w ${PUMA_WORKERS:-3}
+exec env puma -e ${RACK_ENV} -b "ssl://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-443}?key=${PUMA_SSL_KEY}&cert=${PUMA_SSL_CRT}" -w ${PUMA_WORKERS:-3} -C /portus/config/puma.rb ||
+exec env puma -e ${RACK_ENV} -b "tcp://${PUMA_IP:-0.0.0.0}:${PUMA_PORT:-80}" -w ${PUMA_WORKERS:-3} -C /portus/config/puma.rb

--- a/rootfs/portus/config/puma.rb
+++ b/rootfs/portus/config/puma.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env puma
+
+threads 0, 16
+worker_timeout XXX-PUMA_WORKER_TIMEOUT-XXX


### PR DESCRIPTION
This was a strange one. There are two parts:

1. I added ruby-rdoc and ruby-irb to the list of apk installs. Without these `gem update --system` failed with 
```
ERROR:  While executing gem ... (Gem::DocumentError)
    RDoc is not installed: cannot load such file -- rdoc/rdoc
Updating rubygems-update
```
I don't like growing the size of this container but that's what it took for me :\

2. I was running portus on a memory constrained host. As you know rails is very resource heavy. I needed to increase the puma worker timeouts from 60 seconds to 120 seconds to get them to initially boot and cache all of the responses. The only way I found to do this was through a puma config file (no command line flag)

I added that under /portus/config/puma.rb and made the timeout configurable with an environment variable. 


Let me know your thoughts. 

-Connor